### PR TITLE
support-bare

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,5 +18,19 @@
   "bugs": {
     "url": "https://github.com/holepunchto/throwaway-local-cache/issues"
   },
-  "homepage": "https://github.com/holepunchto/throwaway-local-cache"
+  "homepage": "https://github.com/holepunchto/throwaway-local-cache",
+  "dependencies": {
+    "bare-fs": "^4.1.2",
+    "bare-path": "^3.0.0"
+  },
+  "imports": {
+    "fs": {
+      "bare": "bare-fs",
+      "default": "fs"
+    },
+    "path": {
+      "bare": "bare-path",
+      "default": "path"
+    }
+  }
 }


### PR DESCRIPTION
Run `bare example.mjs `

```
Uncaught ModuleError: MODULE_NOT_FOUND: Cannot find module 'fs' imported from ...
```

